### PR TITLE
Full ETS6 Support

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -642,18 +642,20 @@ namespace MultiplyChannels {
                 FileInfo hwFileInfo = new FileInfo(Path.Combine(localPath, "Temp", manuId, "Hardware.xml"));
                 FileInfo catalogFileInfo = new FileInfo(Path.Combine(localPath, "Temp", manuId, "Catalog.xml"));
                 FileInfo appInfo = new FileInfo(Path.Combine(localPath, "Temp", manuId, $"{appId}.xml"));
-                ApplicationProgramHasher aph = new ApplicationProgramHasher(appInfo, mapBaggageIdToFileIntegrity, iPathETS, true);
-                aph.HashFile(); //ETS6 benutzt ApplicationProgramStoreHasher und die Funktion HashStore!
+
+                int nsVersion = int.Parse(ns.Substring(ns.LastIndexOf('/')+1));
+                ApplicationProgramHasher aph = new ApplicationProgramHasher(appInfo, mapBaggageIdToFileIntegrity, iPathETS, nsVersion, true);
+                aph.Hash(); //ETS6 benutzt ApplicationProgramStoreHasher und die Funktion HashStore!
 
                 applProgIdMappings.Add(aph.OldApplProgId, aph.NewApplProgId);
                 if (!applProgHashes.ContainsKey(aph.NewApplProgId))
                     applProgHashes.Add(aph.NewApplProgId, aph.GeneratedHashString);
 
-                HardwareSigner hws = new HardwareSigner(hwFileInfo, applProgIdMappings, applProgHashes, iPathETS, true);
+                HardwareSigner hws = new HardwareSigner(hwFileInfo, applProgIdMappings, applProgHashes, iPathETS, nsVersion, true);
                 hws.SignFile();
                 IDictionary<string, string> hardware2ProgramIdMapping = hws.OldNewIdMappings;
 
-                CatalogIdPatcher cip = new CatalogIdPatcher(catalogFileInfo, hardware2ProgramIdMapping, iPathETS);
+                CatalogIdPatcher cip = new CatalogIdPatcher(catalogFileInfo, hardware2ProgramIdMapping, iPathETS, nsVersion);
                 cip.Patch();
 
                 XmlSigning.SignDirectory(Path.Combine(localPath, "Temp", manuId), iPathETS);

--- a/Program.cs
+++ b/Program.cs
@@ -49,33 +49,49 @@ namespace MultiplyChannels {
             int lProjectVersion = int.Parse(lXmlns.Substring(27));
 
             if (EtsVersions.ContainsKey(lXmlns)) {
-                string lSubdir = EtsVersions[lXmlns].Subdir;
-                string lEts = EtsVersions[lXmlns].ETS;
+                string lEts = "";
+                //if we found an ets6, we can generate all versions with it
+                if(Directory.Exists(@"C:\Program Files (x86)\ETS6")) {
+                    lResult = @"C:\Program Files (x86)\ETS6";
+                    lEts = "ETS 6";
+                }
+                
+                //if we found ets6 dlls, we can generate all versions with it
+                if(Directory.Exists(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "CV", "6.0"))) {
+                    lResult = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "CV", "6.0");
+                    lEts = "ETS 6 (local)";
+                }
 
-                foreach(string path in gPathETS) {
-                    if(!Directory.Exists(path)) continue;
-                    if(Directory.Exists(Path.Combine(path, "CV", lSubdir))) //If subdir exists everything ist fine
-                    {
-                        lResult = Path.Combine(path, "CV", lSubdir);
-                        break;
-                    }
-                    else { //otherwise it might be the file in the root folder
-                        if(!File.Exists(Path.Combine(path, "Knx.Ets.XmlSigning.dll"))) continue;
-                        System.Diagnostics.FileVersionInfo versionInfo = System.Diagnostics.FileVersionInfo.GetVersionInfo(Path.Combine(path, "Knx.Ets.XmlSigning.dll"));
-                        string newVersion = versionInfo.FileVersion;
-                        if (lSubdir.Split('.').Length == 2) newVersion = string.Join('.', newVersion.Split('.').Take(2));
-                        // if(newVersion.Split('.').Length != 4) newVersion += ".0";
+                //else search for an older ETS or CV files
+                if(string.IsNullOrEmpty(lResult)) {
+                    string lSubdir = EtsVersions[lXmlns].Subdir;
+                    lEts = EtsVersions[lXmlns].ETS;
 
-                        if(lSubdir == newVersion)
+                    foreach(string path in gPathETS) {
+                        if(!Directory.Exists(path)) continue;
+                        if(Directory.Exists(Path.Combine(path, "CV", lSubdir))) //If subdir exists everything ist fine
                         {
-                            lResult = path;
+                            lResult = Path.Combine(path, "CV", lSubdir);
                             break;
+                        }
+                        else { //otherwise it might be the file in the root folder
+                            if(!File.Exists(Path.Combine(path, "Knx.Ets.XmlSigning.dll"))) continue;
+                            System.Diagnostics.FileVersionInfo versionInfo = System.Diagnostics.FileVersionInfo.GetVersionInfo(Path.Combine(path, "Knx.Ets.XmlSigning.dll"));
+                            string newVersion = versionInfo.FileVersion;
+                            if (lSubdir.Split('.').Length == 2) newVersion = string.Join('.', newVersion.Split('.').Take(2));
+                            // if(newVersion.Split('.').Length != 4) newVersion += ".0";
+
+                            if(lSubdir == newVersion)
+                            {
+                                lResult = path;
+                                break;
+                            }
                         }
                     }
                 }
                 
                 if (!string.IsNullOrEmpty(lResult))
-                    Console.WriteLine("Found namespace {1} in xml, will use {0} for conversion...", lEts, lXmlns);
+                    Console.WriteLine("Found namespace {1} in xml, will use {0} for conversion... (Path: {2})", lEts, lXmlns, lResult);
             }
             if (string.IsNullOrEmpty(lResult)) Console.WriteLine("No valid conversion engine available for xmlns {0}", lXmlns);
             

--- a/Signing/ApplicationSigner.cs
+++ b/Signing/ApplicationSigner.cs
@@ -7,22 +7,36 @@ namespace MultiplyChannels.Signing
 {
     class ApplicationProgramHasher
     {
+        private int NamespaceVersion;
+
         public ApplicationProgramHasher(
                     FileInfo applProgFile,
                     IDictionary<string, string> mapBaggageIdToFileIntegrity,
                     string basePath,
+                    int nsVersion,
                     bool patchIds = true)
         {
+            NamespaceVersion = nsVersion;
             //if ets6 use ApplicationProgramStoreHasher
             //with HashStore Method
             Assembly asm = Assembly.LoadFrom(Path.Combine(basePath, "Knx.Ets.XmlSigning.dll"));
-            _instance = Activator.CreateInstance(asm.GetType("Knx.Ets.XmlSigning.ApplicationProgramHasher"), applProgFile, mapBaggageIdToFileIntegrity, patchIds);
-            _type = asm.GetType("Knx.Ets.XmlSigning.ApplicationProgramHasher");
+
+            if(basePath.Contains("ETS6") || basePath.Contains("6.0")) { //ab ETS6
+                _instance = Activator.CreateInstance(asm.GetType("Knx.Ets.XmlSigning.ApplicationProgramHasher"), applProgFile, mapBaggageIdToFileIntegrity, patchIds, null);
+                _type = asm.GetType("Knx.Ets.XmlSigning.ApplicationProgramHasher");
+            } else { //für ETS5 und früher
+                _instance = Activator.CreateInstance(asm.GetType("Knx.Ets.XmlSigning.ApplicationProgramHasher"), applProgFile, mapBaggageIdToFileIntegrity, patchIds);
+                _type = asm.GetType("Knx.Ets.XmlSigning.ApplicationProgramHasher");
+            }
         }
 
-        public void HashFile()
+        public void Hash()
         {
-            _type.GetMethod("HashFile", BindingFlags.Instance | BindingFlags.Public).Invoke(_instance, null);
+            //if(NamespaceVersion >= 21) { //ab ETS6
+            //    _type.GetMethod("HashStore", BindingFlags.Instance | BindingFlags.Public).Invoke(_instance, null);
+            //} else { //für ETS5 und früher
+                _type.GetMethod("HashFile", BindingFlags.Instance | BindingFlags.Public).Invoke(_instance, null);
+            //}
         }
 
         public string OldApplProgId

--- a/Signing/ApplicationSigner.cs
+++ b/Signing/ApplicationSigner.cs
@@ -7,8 +7,6 @@ namespace MultiplyChannels.Signing
 {
     class ApplicationProgramHasher
     {
-        private int NamespaceVersion;
-
         public ApplicationProgramHasher(
                     FileInfo applProgFile,
                     IDictionary<string, string> mapBaggageIdToFileIntegrity,
@@ -16,13 +14,14 @@ namespace MultiplyChannels.Signing
                     int nsVersion,
                     bool patchIds = true)
         {
-            NamespaceVersion = nsVersion;
             //if ets6 use ApplicationProgramStoreHasher
             //with HashStore Method
             Assembly asm = Assembly.LoadFrom(Path.Combine(basePath, "Knx.Ets.XmlSigning.dll"));
 
-            if(basePath.Contains("ETS6") || basePath.Contains("6.0")) { //ab ETS6
-                _instance = Activator.CreateInstance(asm.GetType("Knx.Ets.XmlSigning.ApplicationProgramHasher"), applProgFile, mapBaggageIdToFileIntegrity, patchIds, null);
+            if(asm.GetName().Version.ToString().StartsWith("6.0")) { //ab ETS6
+                Assembly objm = Assembly.LoadFrom(Path.Combine(basePath, "Knx.Ets.Xml.ObjectModel.dll"));
+                object knxSchemaVersion = Enum.ToObject(objm.GetType("Knx.Ets.Xml.ObjectModel.KnxXmlSchemaVersion"), nsVersion);
+                _instance = Activator.CreateInstance(asm.GetType("Knx.Ets.XmlSigning.ApplicationProgramHasher"), applProgFile, mapBaggageIdToFileIntegrity, patchIds, knxSchemaVersion);
                 _type = asm.GetType("Knx.Ets.XmlSigning.ApplicationProgramHasher");
             } else { //für ETS5 und früher
                 _instance = Activator.CreateInstance(asm.GetType("Knx.Ets.XmlSigning.ApplicationProgramHasher"), applProgFile, mapBaggageIdToFileIntegrity, patchIds);
@@ -32,11 +31,7 @@ namespace MultiplyChannels.Signing
 
         public void Hash()
         {
-            //if(NamespaceVersion >= 21) { //ab ETS6
-            //    _type.GetMethod("HashStore", BindingFlags.Instance | BindingFlags.Public).Invoke(_instance, null);
-            //} else { //für ETS5 und früher
-                _type.GetMethod("HashFile", BindingFlags.Instance | BindingFlags.Public).Invoke(_instance, null);
-            //}
+             _type.GetMethod("HashFile", BindingFlags.Instance | BindingFlags.Public).Invoke(_instance, null);
         }
 
         public string OldApplProgId

--- a/Signing/CatalogIdPatcher.cs
+++ b/Signing/CatalogIdPatcher.cs
@@ -11,12 +11,14 @@ namespace MultiplyChannels.Signing
             FileInfo catalogFile,
             IDictionary<string, string> hardware2ProgramIdMapping,
             string basePath,
-            int namespaceVersion)
+            int nsVersion)
         {
             Assembly asm = Assembly.LoadFrom(Path.Combine(basePath, "Knx.Ets.XmlSigning.dll"));
 
-            if(basePath.Contains("ETS6") || basePath.Contains("6.0")) {
-                _instance = Activator.CreateInstance(asm.GetType("Knx.Ets.XmlSigning.CatalogIdPatcher"), catalogFile, hardware2ProgramIdMapping, null);
+            if(asm.GetName().Version.ToString().StartsWith("6.0")) {
+                Assembly objm = Assembly.LoadFrom(Path.Combine(basePath, "Knx.Ets.Xml.ObjectModel.dll"));
+                object knxSchemaVersion = Enum.ToObject(objm.GetType("Knx.Ets.Xml.ObjectModel.KnxXmlSchemaVersion"), nsVersion);
+                _instance = Activator.CreateInstance(asm.GetType("Knx.Ets.XmlSigning.CatalogIdPatcher"), catalogFile, hardware2ProgramIdMapping, knxSchemaVersion);
                 _type = asm.GetType("Knx.Ets.XmlSigning.CatalogIdPatcher");
             } else {
                 _instance = Activator.CreateInstance(asm.GetType("Knx.Ets.XmlSigning.CatalogIdPatcher"), catalogFile, hardware2ProgramIdMapping);

--- a/Signing/CatalogIdPatcher.cs
+++ b/Signing/CatalogIdPatcher.cs
@@ -10,11 +10,18 @@ namespace MultiplyChannels.Signing
         public CatalogIdPatcher(
             FileInfo catalogFile,
             IDictionary<string, string> hardware2ProgramIdMapping,
-            string basePath)
+            string basePath,
+            int namespaceVersion)
         {
             Assembly asm = Assembly.LoadFrom(Path.Combine(basePath, "Knx.Ets.XmlSigning.dll"));
-            _instance = Activator.CreateInstance(asm.GetType("Knx.Ets.XmlSigning.CatalogIdPatcher"), catalogFile, hardware2ProgramIdMapping);
-            _type = asm.GetType("Knx.Ets.XmlSigning.CatalogIdPatcher");
+
+            if(basePath.Contains("ETS6") || basePath.Contains("6.0")) {
+                _instance = Activator.CreateInstance(asm.GetType("Knx.Ets.XmlSigning.CatalogIdPatcher"), catalogFile, hardware2ProgramIdMapping, null);
+                _type = asm.GetType("Knx.Ets.XmlSigning.CatalogIdPatcher");
+            } else {
+                _instance = Activator.CreateInstance(asm.GetType("Knx.Ets.XmlSigning.CatalogIdPatcher"), catalogFile, hardware2ProgramIdMapping);
+                _type = asm.GetType("Knx.Ets.XmlSigning.CatalogIdPatcher");
+            }
         }
 
         public void Patch()

--- a/Signing/HardwareSigner.cs
+++ b/Signing/HardwareSigner.cs
@@ -12,6 +12,7 @@ namespace MultiplyChannels.Signing
                 IDictionary<string, string> applProgIdMappings,
                 IDictionary<string, string> applProgHashes,
                 string basePath,
+                int namespaceVersion,
                 bool patchIds)
         {
             Assembly asm1 = Assembly.LoadFrom(Path.Combine(basePath, "Knx.Ets.XmlSigning.dll"));
@@ -20,9 +21,15 @@ namespace MultiplyChannels.Signing
             Type RegistrationKeyEnum = asm2.GetType("Knx.Ets.Xml.ObjectModel.RegistrationKey");
             object registrationKey = Enum.Parse(RegistrationKeyEnum, "knxconv");
 
-            // registrationKey= Knx.Ets.Xml.ObjectModel.RegistrationKey.knxconv (is an enum)
-            _instance = Activator.CreateInstance(asm1.GetType("Knx.Ets.XmlSigning.HardwareSigner"), hardwareFile, applProgIdMappings, applProgHashes, patchIds, registrationKey);
-            _type = asm1.GetType("Knx.Ets.XmlSigning.HardwareSigner");
+            if(basePath.Contains("ETS6") || basePath.Contains("6.0")) {
+                // registrationKey= Knx.Ets.Xml.ObjectModel.RegistrationKey.knxconv (is an enum)
+                _instance = Activator.CreateInstance(asm1.GetType("Knx.Ets.XmlSigning.HardwareSigner"), hardwareFile, applProgIdMappings, applProgHashes, patchIds, registrationKey, null);
+                _type = asm1.GetType("Knx.Ets.XmlSigning.HardwareSigner");
+            } else {
+                // registrationKey= Knx.Ets.Xml.ObjectModel.RegistrationKey.knxconv (is an enum)
+                _instance = Activator.CreateInstance(asm1.GetType("Knx.Ets.XmlSigning.HardwareSigner"), hardwareFile, applProgIdMappings, applProgHashes, patchIds, registrationKey);
+                _type = asm1.GetType("Knx.Ets.XmlSigning.HardwareSigner");
+            }
         }
 
         public void SignFile()

--- a/Signing/HardwareSigner.cs
+++ b/Signing/HardwareSigner.cs
@@ -12,23 +12,24 @@ namespace MultiplyChannels.Signing
                 IDictionary<string, string> applProgIdMappings,
                 IDictionary<string, string> applProgHashes,
                 string basePath,
-                int namespaceVersion,
+                int nsVersion,
                 bool patchIds)
         {
-            Assembly asm1 = Assembly.LoadFrom(Path.Combine(basePath, "Knx.Ets.XmlSigning.dll"));
-            Assembly asm2 = Assembly.LoadFrom(Path.Combine(basePath, "Knx.Ets.Xml.ObjectModel.dll"));
+            Assembly asm = Assembly.LoadFrom(Path.Combine(basePath, "Knx.Ets.XmlSigning.dll"));
+            Assembly objm = Assembly.LoadFrom(Path.Combine(basePath, "Knx.Ets.Xml.ObjectModel.dll"));
 
-            Type RegistrationKeyEnum = asm2.GetType("Knx.Ets.Xml.ObjectModel.RegistrationKey");
+            Type RegistrationKeyEnum = objm.GetType("Knx.Ets.Xml.ObjectModel.RegistrationKey");
             object registrationKey = Enum.Parse(RegistrationKeyEnum, "knxconv");
 
-            if(basePath.Contains("ETS6") || basePath.Contains("6.0")) {
+            if(asm.GetName().Version.ToString().StartsWith("6.0")) {
                 // registrationKey= Knx.Ets.Xml.ObjectModel.RegistrationKey.knxconv (is an enum)
-                _instance = Activator.CreateInstance(asm1.GetType("Knx.Ets.XmlSigning.HardwareSigner"), hardwareFile, applProgIdMappings, applProgHashes, patchIds, registrationKey, null);
-                _type = asm1.GetType("Knx.Ets.XmlSigning.HardwareSigner");
+                object knxSchemaVersion = Enum.ToObject(objm.GetType("Knx.Ets.Xml.ObjectModel.KnxXmlSchemaVersion"), nsVersion);
+                _instance = Activator.CreateInstance(asm.GetType("Knx.Ets.XmlSigning.HardwareSigner"), hardwareFile, applProgIdMappings, applProgHashes, patchIds, registrationKey, knxSchemaVersion);
+                _type = asm.GetType("Knx.Ets.XmlSigning.HardwareSigner");
             } else {
                 // registrationKey= Knx.Ets.Xml.ObjectModel.RegistrationKey.knxconv (is an enum)
-                _instance = Activator.CreateInstance(asm1.GetType("Knx.Ets.XmlSigning.HardwareSigner"), hardwareFile, applProgIdMappings, applProgHashes, patchIds, registrationKey);
-                _type = asm1.GetType("Knx.Ets.XmlSigning.HardwareSigner");
+                _instance = Activator.CreateInstance(asm.GetType("Knx.Ets.XmlSigning.HardwareSigner"), hardwareFile, applProgIdMappings, applProgHashes, patchIds, registrationKey);
+                _type = asm.GetType("Knx.Ets.XmlSigning.HardwareSigner");
             }
         }
 


### PR DESCRIPTION
Tool will use ETS6 files to sign every schemaversion.
Fallback to search and use CV files per schemaversion.